### PR TITLE
feat(scripts): forge-config-check.sh + fixture tests (W1.7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Two operating modes: PRODUCT (work on products) and SELF (work on the forge itse
 ### Core (universal, agent-agnostic)
 `core/` — pure markdown knowledge that any agent can read:
 - `core/skills/` — A-context: expertise per pipeline stage (how to write PRD, how to architect, etc.)
+- `core/skills/INDEX.yaml` — slim catalog of every skill under `core/skills/`; entry skills load it first to pick only the needed stage skill instead of scanning the directory (see `core/skills/INDEX.md` for the contract)
 - `core/pipeline/` — stage definitions, gate format, orchestration rules
 - `core/templates/` — artifact templates (PRD, arch doc, gate report, config.yaml...)
 - `core/registry/` — catalog of known skills and MCP servers

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The user-facing contract should stay simple:
 Every agent should use the same forge contract underneath:
 
 - **State**: GitHub issue + `.forge/pipeline-state.yaml`
-- **Knowledge**: forge base skills + project overlays
+- **Knowledge**: forge base skills + project overlays. Entry skills load `core/skills/INDEX.yaml` first — a slim catalog — and read only the chosen stage skill body. Direct reads of `core/skills/<name>/SKILL.md` remain a supported fallback. See `core/skills/INDEX.md`.
 - **Artifacts**: `docs/strategy`, `docs/research`, `docs/prd` (Behavior Contracts), `docs/architecture`, and later-stage outputs
 - **Canonical intents**:
   - `bugfix`

--- a/core/skills/INDEX.md
+++ b/core/skills/INDEX.md
@@ -1,0 +1,53 @@
+# Forge Skill Catalog (`INDEX.yaml`)
+
+## Purpose
+
+`INDEX.yaml` is a slim, machine-readable catalog of every skill under
+`core/skills/`. It exists so that an agent entering Forge can decide which
+skill body to read without scanning the directory or loading every
+`SKILL.md` up front.
+
+The pattern follows the lazy-loading discipline described in Anthropic's
+"Code execution with MCP" (Nov 2025): keep the dispatch surface small,
+load tool bodies only when the runtime actually needs them.
+
+## Contract
+
+- Every directory under `core/skills/` that contains a `SKILL.md` MUST have
+  exactly one corresponding entry in `INDEX.yaml`.
+- `forge-doctor self` enforces presence, YAML validity, and coverage.
+- The catalog is **additive**. Agents and adapters that read
+  `core/skills/<name>/SKILL.md` directly continue to work. The catalog is a
+  preferred entry point, not a replacement.
+
+## How an agent should use it
+
+1. At session entry, load `core/skills/INDEX.yaml`.
+2. Pick the candidate skill(s) using `kind`, `stage_id`, `triggers`,
+   and current pipeline state from `.forge/pipeline-state.yaml` /
+   `.forge/active-run.env`.
+3. Read the body of the chosen skill from `path`.
+4. Read other skill bodies only if the chosen workflow explicitly hands
+   off to them.
+
+The catalog itself is intentionally small. It is meant to fit comfortably
+in context alongside the chosen stage skill, not to replace it.
+
+## When to update
+
+- Adding a new skill directory under `core/skills/`: append an entry.
+- Renaming a skill directory or its `stage_id`: update the matching
+  entry and any project overlays that reference the old name.
+- Substantially changing the role/triggers/inputs of a skill: refresh
+  `description`, `triggers`, and `inputs`. Keep `description` to one line.
+- `size_lines` is informational. It may drift between edits and is
+  re-synced as a side effect of routine maintenance, not on every commit.
+
+## Non-goals (for this pass)
+
+- This catalog does NOT enforce per-stage MCP loading. The `stages:`
+  field already present in `core/registry/mcp-servers.yaml` continues to
+  describe MCP scoping at a documentary level; runtime enforcement is a
+  separate follow-up.
+- This catalog does NOT split `core/pipeline/orchestrator.md` or
+  `core/pipeline/issue-tracking.md`. Those remain whole references.

--- a/core/skills/INDEX.yaml
+++ b/core/skills/INDEX.yaml
@@ -1,0 +1,290 @@
+# Forge Skill Catalog
+#
+# Slim metadata for every skill under core/skills/.
+# Agents load this catalog at session entry, decide which skill body to read,
+# and read only that file. Direct reads of core/skills/<name>/SKILL.md remain a
+# supported fallback when an agent is invoked outside the catalog flow.
+#
+# Schema (every entry):
+#   name          string  — directory name under core/skills/
+#   kind          enum    — entry | stage | utility
+#   path          string  — repo-relative path to SKILL.md
+#   size_lines    int     — current line count of SKILL.md (informational)
+#   description   string  — one-line purpose, used by the agent to choose
+#   triggers      list    — short intent signals that should route here
+#   inputs        list    — files/artifacts to read alongside this skill
+#
+# Additional for kind=stage:
+#   stage_id      string  — internal stage id used by .forge/pipeline-state.yaml
+#   stage_number  number  — order in the pipeline (matches orchestrator.md)
+#
+# Coverage rule: every directory under core/skills/ that contains SKILL.md MUST
+# appear here exactly once. forge-doctor self enforces this.
+
+skills:
+
+  # ─── Entry skills ────────────────────────────────────────────────────────
+
+  - name: product-entry
+    kind: entry
+    path: core/skills/product-entry/SKILL.md
+    size_lines: 343
+    description: Route a short PRODUCT prompt into the right pipeline stage, lane, and gate behavior.
+    triggers:
+      - "сломалось / не работает / почини"
+      - "хочу / нужно сделать / добавь"
+      - "почему / разберись / аудит"
+      - "залей на тестфлайт / выложи в app store / задеплой веб"
+      - "ок / поехали дальше / approved"
+    inputs:
+      - .forge/active-run.env
+      - .forge/config.yaml
+      - .forge/pipeline-state.yaml
+      - core/pipeline/entry-surface.md
+      - core/pipeline/orchestrator.md
+      - core/pipeline/issue-tracking.md
+
+  - name: self-entry
+    kind: entry
+    path: core/skills/self-entry/SKILL.md
+    size_lines: 54
+    description: Route a short SELF prompt into Scout, Meta, Upgrade, or Retrospective submode inside gulyaev-forge.
+    triggers:
+      - "улучши pipeline"
+      - "сделай forge более рабочим"
+      - "добавь новый MCP"
+      - "измени процесс гейтов"
+      - "упрости запуск PRODUCT/SELF"
+    inputs:
+      - docs/operating-playbook.md
+      - docs/design.md
+      - core/registry/mcp-servers.yaml
+
+  # ─── Pipeline stages (0 → 12, plus 6.5) ──────────────────────────────────
+
+  - name: strategy
+    kind: stage
+    stage_id: strategy
+    stage_number: 0
+    path: core/skills/strategy/SKILL.md
+    size_lines: 144
+    description: Define or update strategic direction — vision, positioning, target metrics, roadmap priorities.
+    triggers:
+      - "стратегия / направление / куда идём"
+      - "pivot / roadmap update"
+    inputs:
+      - docs/strategy/
+      - docs/BACKLOG.md
+
+  - name: discovery
+    kind: stage
+    stage_id: discovery
+    stage_number: 1
+    path: core/skills/discovery/SKILL.md
+    size_lines: 123
+    description: Find user pains, market gaps, competitor insights, and tech trends that inform product decisions.
+    triggers:
+      - "research / исследование"
+      - "конкуренты / market"
+      - "почему отваливаются"
+    inputs:
+      - docs/strategy/
+      - docs/research/
+
+  - name: prd
+    kind: stage
+    stage_id: prd
+    stage_number: 2
+    path: core/skills/prd/SKILL.md
+    size_lines: 172
+    description: Author the Behavior Contract — one compact execution contract for the slice.
+    triggers:
+      - "behavior contract gate"
+      - "PRD"
+      - "контракт поведения"
+    inputs:
+      - approved strategy / discovery artifacts
+      - linked GitHub issue body
+
+  - name: design
+    kind: stage
+    stage_id: design
+    stage_number: 3
+    path: core/skills/design/SKILL.md
+    size_lines: 129
+    description: Translate the Behavior Contract into visual and interaction design specifications.
+    triggers:
+      - "design / UX"
+      - "Figma / макеты"
+    inputs:
+      - approved Behavior Contract
+      - design system docs / tokens
+
+  - name: architecture
+    kind: stage
+    stage_id: architecture
+    stage_number: 4
+    path: core/skills/architecture/SKILL.md
+    size_lines: 217
+    description: Translate the Behavior Contract and design into technical architecture — system design, data, contracts, tech choices.
+    triggers:
+      - "architecture / схема системы"
+      - "API contract / schema / migration"
+    inputs:
+      - approved Behavior Contract
+      - approved design artifacts
+      - current data model / migrations
+
+  - name: test-plan
+    kind: stage
+    stage_id: test_plan
+    stage_number: 5
+    path: core/skills/test-plan/SKILL.md
+    size_lines: 73
+    description: Proof Hardening — tighten the Proof Required section of the approved Behavior Contract before implementation.
+    triggers:
+      - "test plan / proof required"
+      - "proof hardening"
+    inputs:
+      - approved Behavior Contract
+
+  - name: implementation
+    kind: stage
+    stage_id: implementation
+    stage_number: 6
+    path: core/skills/implementation/SKILL.md
+    size_lines: 195
+    description: Implement the approved contract with the smallest safe change set.
+    triggers:
+      - "implement / реализуй"
+      - "bugfix quick path"
+      - "micro_change implementation"
+    inputs:
+      - approved Behavior Contract + design + architecture (when applicable)
+      - project CLAUDE.md / AGENTS.md
+      - linked GitHub issue
+
+  - name: code-review
+    kind: stage
+    stage_id: code_review
+    stage_number: 6.5
+    path: core/skills/code-review/SKILL.md
+    size_lines: 171
+    description: Verify implementation follows the approved contract, uses TDD discipline, and introduces no regressions.
+    triggers:
+      - "code review / ревью кода"
+      - "PR review"
+    inputs:
+      - implementation diff
+      - approved Behavior Contract
+      - project REVIEW.md when present
+
+  - name: test-coverage
+    kind: stage
+    stage_id: test_coverage
+    stage_number: 7
+    path: core/skills/test-coverage/SKILL.md
+    size_lines: 196
+    description: Verify test completeness, fill coverage gaps, ensure the test suite is reliable.
+    triggers:
+      - "coverage / покрытие"
+      - "missing tests"
+    inputs:
+      - implementation diff
+      - existing test suite results
+
+  - name: qa
+    kind: stage
+    stage_id: qa
+    stage_number: 8
+    path: core/skills/qa/SKILL.md
+    size_lines: 205
+    description: Run end-to-end tests against a live environment, verify UI/UX against design, produce a quality report.
+    triggers:
+      - "qa / прогон / smoke"
+      - "release QA"
+    inputs:
+      - approved Behavior Contract acceptance
+      - staging or local URL
+      - design artifacts
+
+  - name: staging-deploy
+    kind: stage
+    stage_id: staging_deploy
+    stage_number: 9
+    path: core/skills/staging-deploy/SKILL.md
+    size_lines: 93
+    description: Deploy the feature to a staging environment for final validation before production.
+    triggers:
+      - "staging deploy / прекат на стейдж"
+    inputs:
+      - approved QA report
+      - deploy/ runbooks
+
+  - name: canary-deploy
+    kind: stage
+    stage_id: canary_deploy
+    stage_number: 10
+    path: core/skills/canary-deploy/SKILL.md
+    size_lines: 133
+    description: Gradually roll out to production, monitoring for issues at each step.
+    triggers:
+      - "canary / постепенный rollout"
+      - "production rollout"
+    inputs:
+      - staging deploy evidence
+      - rollback runbook
+
+  - name: product-analytics
+    kind: stage
+    stage_id: product_analytics
+    stage_number: 11
+    path: core/skills/product-analytics/SKILL.md
+    size_lines: 137
+    description: Measure feature impact against Behavior Contract success metrics; recommend next actions.
+    triggers:
+      - "метрики / retention / конверсия / воронка / аналитика"
+    inputs:
+      - Behavior Contract success metrics
+      - analytics dashboards / queries
+
+  - name: tech-monitoring
+    kind: stage
+    stage_id: tech_monitoring
+    stage_number: 12
+    path: core/skills/tech-monitoring/SKILL.md
+    size_lines: 136
+    description: Monitor technical health of a deployed feature — errors, performance, infra, user-impacting issues.
+    triggers:
+      - "alerts / тех-мониторинг"
+      - "post-release health"
+    inputs:
+      - error tracking dashboards
+      - infra metrics
+
+  # ─── Utility skills (no fixed stage) ─────────────────────────────────────
+
+  - name: investigate
+    kind: utility
+    path: core/skills/investigate/SKILL.md
+    size_lines: 135
+    description: Evidence-first investigation and audit mode — collect evidence before proposing changes.
+    triggers:
+      - "почему / разберись / аудит / проверь"
+      - "incident analysis"
+      - "architecture review"
+    inputs:
+      - relevant project artifacts under investigation
+      - core/templates/investigation-report-template.md
+
+  - name: scout
+    kind: utility
+    path: core/skills/scout/SKILL.md
+    size_lines: 151
+    description: Evaluate a new tool, framework, MCP server, adapter, or workflow candidate for forge.
+    triggers:
+      - "посмотри вот это / оценим инструмент"
+      - "new MCP / new skill / new framework"
+    inputs:
+      - core/registry/mcp-servers.yaml
+      - docs/research/scout-queue.md

--- a/core/skills/product-entry/SKILL.md
+++ b/core/skills/product-entry/SKILL.md
@@ -216,19 +216,24 @@ The agent must translate natural approval into the durable issue comment format 
 1. Run product preflight from the current product repo using the same forge checkout that provided this skill:
    - `bash <forge-root>/scripts/forge-doctor.sh product .`
    - `bash <forge-root>/scripts/forge-status.sh product .`
-2. Read:
+2. Load the slim skill catalog before reading any other stage skill body:
+   - `<forge-root>/core/skills/INDEX.yaml`
+   - use it to pick the correct stage / utility skill from triggers, `kind`, and `stage_id`
+   - read the chosen skill body from its `path` field
+   - direct reads of `<forge-root>/core/skills/<name>/SKILL.md` remain a supported fallback when the catalog is unavailable or out of date
+3. Read:
    - `.forge/active-run.env` first, if present
    - `.forge/config.yaml`
    - `.forge/pipeline-state.yaml`
    - the linked GitHub issue
    - the latest approved artifact for the current stage, if any
    - governance/strategy/backlog docs required by the stage
-3. If `.forge/active-run.env` describes an active bugfix quick run:
+4. If `.forge/active-run.env` describes an active bugfix quick run:
    - treat it as the current workflow instead of the unrelated feature pipeline
    - use its issue as the execution contract
    - respect its current quick-path stage and gate status
    - do not lose or overwrite it just because `.forge/pipeline-state.yaml` points to a different feature
-4. Check gate lock before advancing:
+5. Check gate lock before advancing:
    - if the current stage is gated and `current_gate_status` is `pending_approval`, stop at that gate
    - if the current stage is gated and there is no explicit approval recorded yet, treat it as `pending_approval`
    - when a gate is pending or the user asks for an approval decision, assess it independently from:
@@ -242,15 +247,16 @@ The agent must translate natural approval into the durable issue comment format 
      - `/gate rejected`
    - if the user approves in the current chat, mirror that decision into the GitHub issue before updating stage labels or `.forge/pipeline-state.yaml`
    - for an active bugfix quick run, mirror the same decision into `.forge/active-run.env`
-5. Resolve the target stage from intent:
+6. Resolve the target stage from intent:
    - if the user names a target stage or gate, treat it as the desired destination, not permission to skip unresolved gates
    - otherwise infer the path from bug / feature / question / metrics intent
    - for feature/change requests, choose `micro_change`, `small_change`, or `full_feature` before choosing the starting stage
    - stop at the first unresolved gated stage on the path
-6. Load the correct stage context:
-   - forge base skill: `<forge-root>/core/skills/[stage]/SKILL.md`
+7. Load the correct stage context:
+   - resolve the stage skill via `<forge-root>/core/skills/INDEX.yaml` (look up by `stage_id`); the `path` field points at the canonical SKILL.md
+   - fallback if the catalog is unavailable: `<forge-root>/core/skills/[stage]/SKILL.md`
    - project overlay: `.forge/skills/[stage].md` if present
-7. Work as that stage role.
+8. Work as that stage role.
    - Do not default to implementation unless the target stage really is implementation or later.
    - If the current stage remains in progress and no gate is required yet, present a checkpoint, not a vague progress note.
    - For non-gated stages such as `code_review` and `test_coverage`, auto-proceed to the next allowed stage when criteria are satisfied instead of stopping for internal execution choices.
@@ -275,7 +281,7 @@ The agent must translate natural approval into the durable issue comment format 
      - do not end with open-ended prompts like `что дальше?` when the next step is already clear
      - if `Gate needed now: no` and no missing input/secret/approval is required, say the localized equivalent of `Needs from moderator: none` and continue
      - Russian short replies such as `продолжай`, `запусти review`, `прогони qa`, and `покажи gate` are valid equivalents
-8. Before claiming a stage slice or issue is complete:
+9. Before claiming a stage slice or issue is complete:
    - map every required issue acceptance item or rollout note to one of:
      - proven with concrete evidence
      - explicitly deferred with approval

--- a/core/skills/self-entry/SKILL.md
+++ b/core/skills/self-entry/SKILL.md
@@ -24,17 +24,22 @@ Use it before making forge changes when the user gives a short prompt and expect
 1. Run self preflight:
    - `bash scripts/forge-doctor.sh self .`
    - `bash scripts/forge-status.sh self .`
-2. Read:
+2. Load the slim skill catalog before reading other skill bodies:
+   - `core/skills/INDEX.yaml`
+   - use it to find utility skills (`scout`, `investigate`) or stage skills relevant to the requested forge change
+   - read each chosen skill body from its `path` field
+   - direct reads of `core/skills/<name>/SKILL.md` remain a supported fallback when the catalog is unavailable or out of date
+3. Read:
    - `docs/operating-playbook.md`
    - `docs/design.md`
    - the most relevant files under `core/`, `docs/`, `scripts/`
-3. Resolve the submode:
+4. Resolve the submode:
    - tool evaluation -> `Scout`
    - process / skill / template / adapter change -> `Meta`
    - version / runtime / MCP upgrade -> `Upgrade`
    - analyze pain points -> `Retrospective`
-4. Execute the task in that submode.
-5. If the forge change affects a connected product, validate it in that product repo after editing forge.
+5. Execute the task in that submode.
+6. If the forge change affects a connected product, validate it in that product repo after editing forge.
 
 For `Scout` work specifically:
 - use `core/skills/scout/SKILL.md`

--- a/docs/design.md
+++ b/docs/design.md
@@ -513,6 +513,8 @@ forge init --project ./spodi
 gulyaev-forge/
   core/                          # Универсальные знания (чистый markdown)
     skills/                      # A-контексты по ролям
+      INDEX.yaml                 # Slim каталог всех skills (имя, kind, stage_id, triggers, inputs, path)
+      INDEX.md                   # Контракт каталога и правила обновления
       strategy/SKILL.md
       discovery/SKILL.md
       prd/SKILL.md
@@ -602,6 +604,14 @@ project/.forge/skills/
 4. adapter shim (`.claude/skills`, `AGENTS.md`, `.cursor/rules/...`)
 
 Adapter-файлы должны считаться доставочным слоем, а не первичным source of truth.
+
+### Skill catalog (`core/skills/INDEX.yaml`)
+
+`core/skills/INDEX.yaml` — slim каталог всех skills под `core/skills/`. Entry skills читают его на входе, чтобы выбрать только тот stage skill, который нужен текущей задаче, вместо того чтобы сканировать директорию или грузить тела всех skills.
+
+Контракт каталога описан в `core/skills/INDEX.md`. Coverage и базовая валидность YAML проверяются `bash scripts/forge-doctor.sh self .`.
+
+Изменение **additive**: прямое чтение `core/skills/<name>/SKILL.md` остаётся поддерживаемым fallback.
 
 ---
 

--- a/docs/operating-playbook.md
+++ b/docs/operating-playbook.md
@@ -15,6 +15,8 @@ Short prompts should first route through an entry skill:
 - `core/skills/product-entry/SKILL.md` for PRODUCT work
 - `core/skills/self-entry/SKILL.md` for SELF work
 
+Both entry skills load `core/skills/INDEX.yaml` — a slim catalog of every skill under `core/skills/` — and use it to pick which stage or utility skill body to read. Direct reads of `core/skills/<name>/SKILL.md` remain a supported fallback when the catalog is unavailable. See `core/skills/INDEX.md` for the catalog contract.
+
 After that, every stage should be assembled from four layers:
 
 1. **Forge base skill**

--- a/scripts/fixtures/forge-config-check/edge-cases/.forge/config.yaml
+++ b/scripts/fixtures/forge-config-check/edge-cases/.forge/config.yaml
@@ -1,0 +1,46 @@
+project:
+  name: edge-cases-fixture
+  description: "config with comments mid-block, quoted paths, anchors, empty if_exists, nested-name-collision"
+  stage: mvp
+
+# Top-level comment
+
+metrics:
+  # commented-out baseline (should not be picked up)
+  # baseline: docs/old-baseline.md
+  analytics_provider: custom   # inline comment
+
+release_targets:
+  ios_testflight:
+    platform: ios
+    channel: testflight
+    runbook: "docs/runbook.md#testflight"   # anchored, quoted
+  web_production:
+    platform: web
+    channel: production
+    runbook: docs/runbook.md#web-production   # anchored, unquoted
+
+stage_agents:
+  code_review:
+    reviewer:
+      adapter: codex-review
+      prompt_file: .forge/reviewer.md
+    # legal-reviewer disabled — no prompt_file (should be silently skipped)
+
+stages:
+  strategy:
+    inject:
+      required:
+        - "docs/strategy.md"      # quoted path
+      if_exists: []               # explicit empty list
+  design:
+    inject:
+      required: []
+      if_exists: []
+  implementation:
+    inject:
+      required:
+        - CLAUDE.md
+      # commented-out optional bucket
+      # if_exists:
+      #   - docs/notes.md

--- a/scripts/fixtures/forge-config-check/edge-cases/.forge/reviewer.md
+++ b/scripts/fixtures/forge-config-check/edge-cases/.forge/reviewer.md
@@ -1,0 +1,1 @@
+# Reviewer prompt (fixture)

--- a/scripts/fixtures/forge-config-check/edge-cases/CLAUDE.md
+++ b/scripts/fixtures/forge-config-check/edge-cases/CLAUDE.md
@@ -1,0 +1,1 @@
+# CLAUDE.md (fixture)

--- a/scripts/fixtures/forge-config-check/edge-cases/docs/runbook.md
+++ b/scripts/fixtures/forge-config-check/edge-cases/docs/runbook.md
@@ -1,0 +1,1 @@
+# Runbook (fixture)

--- a/scripts/fixtures/forge-config-check/edge-cases/docs/strategy.md
+++ b/scripts/fixtures/forge-config-check/edge-cases/docs/strategy.md
@@ -1,0 +1,1 @@
+# Strategy (fixture)

--- a/scripts/fixtures/forge-config-check/missing-required/.forge/config.yaml
+++ b/scripts/fixtures/forge-config-check/missing-required/.forge/config.yaml
@@ -1,0 +1,13 @@
+project:
+  name: missing-required-fixture
+  description: "config with a missing required: path — script must exit 1"
+  stage: mvp
+
+stages:
+  strategy:
+    inject:
+      required:
+        - docs/strategy.md           # exists
+        - docs/does-not-exist.md     # MISSING — should error
+      if_exists:
+        - docs/optional-missing.md   # MISSING — should warn only

--- a/scripts/fixtures/forge-config-check/missing-required/docs/strategy.md
+++ b/scripts/fixtures/forge-config-check/missing-required/docs/strategy.md
@@ -1,0 +1,1 @@
+# Strategy (fixture)

--- a/scripts/fixtures/forge-config-check/valid/.forge/config.yaml
+++ b/scripts/fixtures/forge-config-check/valid/.forge/config.yaml
@@ -1,0 +1,36 @@
+project:
+  name: valid-fixture
+  description: "minimal valid config — every referenced path resolves"
+  stage: mvp
+
+agents:
+  - claude-code
+
+metrics:
+  baseline: docs/baseline.md
+  analytics_provider: custom
+
+release_targets:
+  prod:
+    platform: web
+    channel: production
+    deploy_stage: canary_deploy
+    runbook: docs/runbook.md
+
+stage_agents:
+  code_review:
+    reviewer:
+      adapter: codex-review
+      prompt_file: .forge/reviewer.md
+
+stages:
+  strategy:
+    inject:
+      required:
+        - docs/strategy.md
+      if_exists:
+        - docs/baseline.md
+  implementation:
+    inject:
+      required:
+        - CLAUDE.md

--- a/scripts/fixtures/forge-config-check/valid/.forge/reviewer.md
+++ b/scripts/fixtures/forge-config-check/valid/.forge/reviewer.md
@@ -1,0 +1,1 @@
+# Reviewer prompt (fixture)

--- a/scripts/fixtures/forge-config-check/valid/CLAUDE.md
+++ b/scripts/fixtures/forge-config-check/valid/CLAUDE.md
@@ -1,0 +1,1 @@
+# CLAUDE.md (fixture)

--- a/scripts/fixtures/forge-config-check/valid/docs/baseline.md
+++ b/scripts/fixtures/forge-config-check/valid/docs/baseline.md
@@ -1,0 +1,1 @@
+# Baseline (fixture)

--- a/scripts/fixtures/forge-config-check/valid/docs/runbook.md
+++ b/scripts/fixtures/forge-config-check/valid/docs/runbook.md
@@ -1,0 +1,1 @@
+# Runbook (fixture)

--- a/scripts/fixtures/forge-config-check/valid/docs/strategy.md
+++ b/scripts/fixtures/forge-config-check/valid/docs/strategy.md
@@ -1,0 +1,1 @@
+# Strategy (fixture)

--- a/scripts/forge-config-check.sh
+++ b/scripts/forge-config-check.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# forge-config-check.sh — validate path references in .forge/config.yaml
+#
+# Built for Agent-Ready 2026 program W1.7 (codex W0 P1.5 fixture coverage).
+# Validates that every path-like value in .forge/config.yaml points to a real file
+# in the project. Fails on missing `required:` injects and missing
+# stage_agents prompts/runbooks. Warns on missing `if_exists:` and optional fields.
+#
+# Usage:
+#   bash scripts/forge-config-check.sh [project-dir]
+#   bash scripts/forge-config-check.sh /path/to/spodi
+#
+# Exit codes:
+#   0 — no errors (warnings allowed)
+#   1 — at least one error (missing required path)
+#   2 — usage error / config not found
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/forge-config-check.sh [project-dir]
+
+Exit codes:
+  0 — no errors (warnings allowed)
+  1 — at least one error (missing required path)
+  2 — usage error / config not found
+EOF
+}
+
+PROJECT_DIR="${1:-.}"
+if [[ "$PROJECT_DIR" == "-h" || "$PROJECT_DIR" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ ! -d "$PROJECT_DIR" ]]; then
+  printf 'ERR  project dir not found: %s\n' "$PROJECT_DIR" >&2
+  exit 2
+fi
+
+CONFIG="$PROJECT_DIR/.forge/config.yaml"
+if [[ ! -f "$CONFIG" ]]; then
+  printf 'ERR  .forge/config.yaml not found at %s\n' "$CONFIG" >&2
+  exit 2
+fi
+
+ERRORS=0
+WARNINGS=0
+
+ok()   { printf 'OK   %s\n' "$1"; }
+warn() { printf 'WARN %s\n' "$1"; WARNINGS=$((WARNINGS + 1)); }
+err()  { printf 'ERR  %s\n' "$1"; ERRORS=$((ERRORS + 1)); }
+
+# Strip leading/trailing whitespace and surrounding double quotes
+trim() {
+  sed -E 's/^[[:space:]]*//; s/[[:space:]]*$//; s/^"//; s/"$//'
+}
+
+# Strip `#section` anchor from a path-with-anchor like CLAUDE.md#testflight
+strip_anchor() {
+  sed -E 's/#.*$//'
+}
+
+# Resolve a path-or-anchor relative to project-dir and check existence
+check_path() {
+  local path="$1"
+  local field="$2"
+  local severity="$3"   # required | optional
+  local stripped
+  stripped=$(printf '%s' "$path" | strip_anchor)
+
+  # Empty path after stripping → skip silently (commented-out entry)
+  if [[ -z "$stripped" ]]; then
+    return
+  fi
+
+  local full="$PROJECT_DIR/$stripped"
+  if [[ -e "$full" ]]; then
+    ok "$field → $path"
+  else
+    if [[ "$severity" == "required" ]]; then
+      err "$field references missing path: $path"
+    else
+      warn "$field references missing path (optional): $path"
+    fi
+  fi
+}
+
+# Extract stage.inject paths. Emits lines: <stage>\t<required|if_exists>\t<path>
+extract_stage_injects() {
+  awk '
+    BEGIN { in_stages=0; in_stage=""; in_inject=0; bucket="" }
+    /^stages:$/ { in_stages=1; next }
+    # Leaving stages block: any unindented non-empty non-comment line
+    in_stages && /^[^[:space:]#]/ { exit }
+    # New stage header: "  <name>:"
+    in_stages && match($0, /^  [a-z_]+:[[:space:]]*$/) {
+      in_stage=$0
+      sub(/^  /, "", in_stage); sub(/:.*/, "", in_stage)
+      in_inject=0; bucket=""
+      next
+    }
+    # inject: marker (4-space indent inside stage)
+    in_stages && in_stage != "" && match($0, /^    inject:[[:space:]]*$/) {
+      in_inject=1; bucket=""
+      next
+    }
+    # Leaving inject block: any line not indented at least 4 spaces
+    in_inject && /^    [a-z_]+:/ && $0 !~ /^      / && $0 !~ /^    inject:/ {
+      in_inject=0; bucket=""
+    }
+    # required: or if_exists: bucket header (6-space indent)
+    in_inject && match($0, /^      (required|if_exists):/) {
+      bucket=$0
+      sub(/^      /, "", bucket); sub(/:.*/, "", bucket)
+      next
+    }
+    # List entry under a bucket (8-space indent + "- ")
+    in_inject && bucket != "" && match($0, /^        - /) {
+      path=$0
+      sub(/^        - /, "", path)
+      sub(/[[:space:]]+#.*/, "", path)
+      gsub(/^"|"$/, "", path)
+      if (path != "") {
+        printf "%s\t%s\t%s\n", in_stage, bucket, path
+      }
+      next
+    }
+  ' "$CONFIG"
+}
+
+# Extract metrics.baseline scalar
+extract_metrics_baseline() {
+  awk '
+    /^metrics:$/ { in_metrics=1; next }
+    in_metrics && /^[^[:space:]#]/ { exit }
+    in_metrics && match($0, /^  baseline:[[:space:]]*/) {
+      v=$0
+      sub(/^  baseline:[[:space:]]*/, "", v)
+      sub(/[[:space:]]+#.*/, "", v)
+      gsub(/^"|"$/, "", v)
+      print v
+      exit
+    }
+  ' "$CONFIG"
+}
+
+# Extract release_targets.*.runbook entries
+extract_release_runbooks() {
+  awk '
+    /^release_targets:$/ { in_rt=1; current=""; next }
+    in_rt && /^[^[:space:]#]/ { exit }
+    in_rt && match($0, /^  [a-z_]+:[[:space:]]*$/) {
+      current=$0; sub(/^  /, "", current); sub(/:.*/, "", current)
+      next
+    }
+    in_rt && current != "" && match($0, /^    runbook:[[:space:]]*/) {
+      v=$0
+      sub(/^    runbook:[[:space:]]*/, "", v)
+      sub(/[[:space:]]+#.*/, "", v)
+      gsub(/^"|"$/, "", v)
+      if (v != "") printf "%s\t%s\n", current, v
+    }
+  ' "$CONFIG"
+}
+
+# Extract stage_agents.*.*.prompt_file entries
+extract_stage_agent_prompts() {
+  awk '
+    /^stage_agents:$/ { in_sa=1; stage=""; role=""; next }
+    in_sa && /^[^[:space:]#]/ { exit }
+    in_sa && match($0, /^  [a-z_]+:[[:space:]]*$/) {
+      stage=$0; sub(/^  /, "", stage); sub(/:.*/, "", stage)
+      role=""; next
+    }
+    in_sa && match($0, /^    [a-z_-]+:[[:space:]]*$/) {
+      role=$0; sub(/^    /, "", role); sub(/:.*/, "", role)
+      next
+    }
+    in_sa && stage != "" && role != "" && match($0, /^      prompt_file:[[:space:]]*/) {
+      v=$0
+      sub(/^      prompt_file:[[:space:]]*/, "", v)
+      sub(/[[:space:]]+#.*/, "", v)
+      gsub(/^"|"$/, "", v)
+      if (v != "") printf "%s/%s\t%s\n", stage, role, v
+    }
+  ' "$CONFIG"
+}
+
+printf '== forge-config-check ==\n'
+printf 'project: %s\n' "$PROJECT_DIR"
+printf 'config:  %s\n\n' "$CONFIG"
+
+# 1. stages.*.inject — required (error) + if_exists (warn)
+printf -- '-- stages.inject --\n'
+while IFS=$'\t' read -r stage bucket path; do
+  [[ -z "$path" ]] && continue
+  if [[ "$bucket" == "required" ]]; then
+    check_path "$path" "stages.$stage.inject.required" "required"
+  else
+    check_path "$path" "stages.$stage.inject.if_exists" "optional"
+  fi
+done < <(extract_stage_injects)
+
+# 2. metrics.baseline (optional)
+printf -- '\n-- metrics.baseline --\n'
+baseline=$(extract_metrics_baseline | trim)
+if [[ -n "$baseline" ]]; then
+  check_path "$baseline" "metrics.baseline" "optional"
+else
+  printf 'OK   metrics.baseline not set (acceptable; defer real baseline)\n'
+fi
+
+# 3. release_targets.*.runbook (required, anchor-aware)
+printf -- '\n-- release_targets.runbook --\n'
+while IFS=$'\t' read -r target runbook; do
+  [[ -z "$runbook" ]] && continue
+  check_path "$runbook" "release_targets.$target.runbook" "required"
+done < <(extract_release_runbooks)
+
+# 4. stage_agents.*.*.prompt_file (required)
+printf -- '\n-- stage_agents.prompt_file --\n'
+while IFS=$'\t' read -r ident prompt; do
+  [[ -z "$prompt" ]] && continue
+  check_path "$prompt" "stage_agents.$ident.prompt_file" "required"
+done < <(extract_stage_agent_prompts)
+
+printf '\n== summary ==\n'
+printf 'errors:   %d\n' "$ERRORS"
+printf 'warnings: %d\n' "$WARNINGS"
+
+if (( ERRORS > 0 )); then
+  exit 1
+fi
+exit 0

--- a/scripts/forge-config-check.test.sh
+++ b/scripts/forge-config-check.test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# forge-config-check.test.sh — fixture tests for forge-config-check.sh
+#
+# Per codex W0 P1.5 — shell/awk YAML parsing is brittle; fixtures are the safety belt.
+# 3 fixtures cover: (a) all-valid config, (b) missing required path, (c) edge cases
+# (comments mid-block, quoted paths, anchored runbook, empty if_exists, disabled
+# stage agent with no prompt_file).
+#
+# Usage:
+#   bash scripts/forge-config-check.test.sh
+#
+# Exit codes:
+#   0 — all fixtures pass
+#   1 — at least one fixture failed expectations
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHECK="$SCRIPT_DIR/forge-config-check.sh"
+FIXTURES="$SCRIPT_DIR/fixtures/forge-config-check"
+
+if [[ ! -x "$CHECK" ]]; then
+  chmod +x "$CHECK" 2>/dev/null || true
+fi
+
+PASS=0
+FAIL=0
+
+run_fixture() {
+  local name="$1"
+  local expected_exit="$2"
+  local expected_grep="$3"
+
+  local dir="$FIXTURES/$name"
+  if [[ ! -d "$dir" ]]; then
+    printf 'FAIL %-20s — fixture dir missing: %s\n' "$name" "$dir"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  local out
+  local rc=0
+  out=$(bash "$CHECK" "$dir" 2>&1) || rc=$?
+
+  if [[ "$rc" != "$expected_exit" ]]; then
+    printf 'FAIL %-20s — expected exit %s, got %s\n' "$name" "$expected_exit" "$rc"
+    printf '%s\n' "$out" | sed 's/^/     /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  if [[ -n "$expected_grep" ]]; then
+    if ! printf '%s\n' "$out" | grep -q -- "$expected_grep"; then
+      printf 'FAIL %-20s — output missing expected substring: %s\n' "$name" "$expected_grep"
+      printf '%s\n' "$out" | sed 's/^/     /'
+      FAIL=$((FAIL + 1))
+      return
+    fi
+  fi
+
+  printf 'PASS %-20s (exit %s)\n' "$name" "$rc"
+  PASS=$((PASS + 1))
+}
+
+printf '== forge-config-check fixture tests ==\n\n'
+
+# Fixture 1: all-valid config — script must exit 0 with no errors
+run_fixture "valid" 0 "errors:   0"
+
+# Fixture 2: required path missing — script must exit 1 and name the missing path
+run_fixture "missing-required" 1 "docs/does-not-exist.md"
+
+# Fixture 3: edge cases (quoted paths, anchors, commented entries, empty if_exists)
+#  — script must exit 0 AND must not warn about the commented-out baseline / disabled legal-reviewer
+run_fixture "edge-cases" 0 "errors:   0"
+
+# Extra check on edge-cases output: commented baseline must NOT appear
+EDGE_OUT=$(bash "$CHECK" "$FIXTURES/edge-cases" 2>&1 || true)
+if printf '%s\n' "$EDGE_OUT" | grep -q "docs/old-baseline.md"; then
+  printf 'FAIL %-20s — picked up commented-out baseline path\n' "edge-cases-comments"
+  FAIL=$((FAIL + 1))
+else
+  printf 'PASS %-20s (commented baseline ignored)\n' "edge-cases-comments"
+  PASS=$((PASS + 1))
+fi
+
+# Extra check: anchored runbook resolves correctly
+if printf '%s\n' "$EDGE_OUT" | grep -q "release_targets.ios_testflight.runbook → docs/runbook.md#testflight"; then
+  printf 'PASS %-20s (anchored runbook resolved)\n' "edge-cases-anchor"
+  PASS=$((PASS + 1))
+else
+  printf 'FAIL %-20s (anchored runbook NOT resolved)\n' "edge-cases-anchor"
+  printf '%s\n' "$EDGE_OUT" | sed 's/^/     /'
+  FAIL=$((FAIL + 1))
+fi
+
+printf '\n== summary ==\n'
+printf 'pass: %d\n' "$PASS"
+printf 'fail: %d\n' "$FAIL"
+
+if (( FAIL > 0 )); then
+  exit 1
+fi
+exit 0

--- a/scripts/forge-doctor.sh
+++ b/scripts/forge-doctor.sh
@@ -333,6 +333,79 @@ check_self_mcp_server() {
   fi
 }
 
+check_self_skill_index() {
+  local dir=$1
+  local index="$dir/core/skills/INDEX.yaml"
+  local index_names_file
+  local skill_dirs_file
+  local skill_dir
+  local idx_name
+  local missing_count=0
+  local extra_count=0
+  local total_dirs=0
+
+  if [[ ! -f "$index" ]]; then
+    err "core/skills/INDEX.yaml missing"
+    return
+  fi
+  ok "core/skills/INDEX.yaml present"
+
+  index_names_file=$(mktemp)
+  skill_dirs_file=$(mktemp)
+
+  awk '
+    /^skills:[[:space:]]*$/ { in_skills=1; next }
+    in_skills && /^[^[:space:]]/ { in_skills=0 }
+    in_skills && /^[[:space:]]*-[[:space:]]*name:/ {
+      sub(/^[[:space:]]*-[[:space:]]*name:[[:space:]]*/, "", $0)
+      sub(/[[:space:]]+#.*$/, "", $0)
+      gsub(/^"|"$/, "", $0)
+      print
+    }
+  ' "$index" | sort -u > "$index_names_file"
+
+  for f in "$dir"/core/skills/*/SKILL.md; do
+    [[ -f "$f" ]] || continue
+    basename "$(dirname "$f")"
+  done | sort -u > "$skill_dirs_file"
+
+  total_dirs=$(wc -l < "$skill_dirs_file" | tr -d ' ')
+
+  while IFS= read -r skill_dir; do
+    [[ -z "$skill_dir" ]] && continue
+    if ! grep -Fxq "$skill_dir" "$index_names_file"; then
+      err "INDEX.yaml missing entry for skill directory: $skill_dir"
+      missing_count=$((missing_count + 1))
+    fi
+  done < "$skill_dirs_file"
+
+  while IFS= read -r idx_name; do
+    [[ -z "$idx_name" ]] && continue
+    if ! grep -Fxq "$idx_name" "$skill_dirs_file"; then
+      err "INDEX.yaml references nonexistent skill: $idx_name"
+      extra_count=$((extra_count + 1))
+    fi
+  done < "$index_names_file"
+
+  if [[ "$missing_count" -eq 0 && "$extra_count" -eq 0 ]]; then
+    ok "INDEX.yaml covers all $total_dirs skill directories"
+  fi
+
+  rm -f "$index_names_file" "$skill_dirs_file"
+
+  if grep -q $'\t' "$index" 2>/dev/null; then
+    warn "INDEX.yaml contains tab characters (YAML requires spaces)"
+  fi
+
+  if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" 2>/dev/null; then
+    if python3 -c "import yaml,sys; yaml.safe_load(open('$index'))" 2>/dev/null; then
+      ok "INDEX.yaml parses as valid YAML"
+    else
+      err "INDEX.yaml fails YAML parse"
+    fi
+  fi
+}
+
 check_self_mcp_setup() {
   local user_config
   local settings
@@ -714,6 +787,7 @@ doctor_self() {
     fi
   done
 
+  check_self_skill_index "$dir"
   check_self_mcp_setup
   check_self_codex_mcp_setup
 }

--- a/scripts/forge-doctor.sh
+++ b/scripts/forge-doctor.sh
@@ -917,6 +917,21 @@ doctor_product() {
   check_release_targets "$dir" "$config"
   check_product_hooks "$dir"
 
+  # forge-config-check (Agent-Ready 2026 W1.7) — validate every path ref in config.yaml
+  local forge_root_for_check cc_output cc_rc cc_errors cc_warnings
+  forge_root_for_check=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+  if [[ -x "$forge_root_for_check/scripts/forge-config-check.sh" ]]; then
+    cc_rc=0
+    cc_output=$(bash "$forge_root_for_check/scripts/forge-config-check.sh" "$dir" 2>&1) || cc_rc=$?
+    cc_errors=$(printf '%s\n' "$cc_output" | awk '/^errors:/ {print $2; exit}')
+    cc_warnings=$(printf '%s\n' "$cc_output" | awk '/^warnings:/ {print $2; exit}')
+    if [[ "$cc_rc" -eq 0 && "${cc_errors:-0}" -eq 0 ]]; then
+      ok "forge-config-check: all path refs resolve (warnings: ${cc_warnings:-0})"
+    else
+      err "forge-config-check: ${cc_errors:-?} broken path ref(s); run: bash scripts/forge-config-check.sh $dir"
+    fi
+  fi
+
   if [[ -f "$dir/docs/BUSINESS_RULES.md" ]]; then
     ok "BUSINESS_RULES.md present"
     local forge_root


### PR DESCRIPTION
## Summary
- New `scripts/forge-config-check.sh` validates every path reference in a project's `.forge/config.yaml`
- `scripts/forge-config-check.test.sh` with 5 assertions over 3 fixtures
- Integrated into `scripts/forge-doctor.sh` (product mode)
- Enforces the W1.1 invariant going forward: no broken refs slip back in silently

## Why
Wave 1 atom 1.7 of the Agent-Ready 2026 program — spec lives in [spodi:docs/superpowers/specs/2026-05-24-agent-ready-cleanup-design.md](https://github.com/maxgulyaev/spodi/blob/docs/agent-ready-program-spec/docs/superpowers/specs/2026-05-24-agent-ready-cleanup-design.md). Per codex W0 P1.5: shell/awk YAML parsing is brittle, so fixtures cover the supported edge cases. Future surprises = add a new fixture, then patch the parser.

## Validates
- `stages.*.inject.required` — error if missing
- `stages.*.inject.if_exists` — warn if missing  
- `metrics.baseline` — warn if set and missing (no fake placeholder allowed per codex W0 P1.2)
- `release_targets.*.runbook` — error if file missing (anchor-aware: `file.md#section` strips anchor before existence check)
- `stage_agents.*.*.prompt_file` — error if missing

## Fixtures
| Fixture | Expected | Covers |
|---|---|---|
| `valid/` | exit 0, 0 errors | clean config, all refs resolve |
| `missing-required/` | exit 1, names path | broken `required:` path → must error and identify |
| `edge-cases/` | exit 0, 0 errors | quoted paths, anchored runbooks (`docs/runbook.md#testflight`), commented-out entries, empty `if_exists: []`, disabled stage agent without `prompt_file` |

5/5 assertions pass locally.

## End-to-end against spodi (post-W1.1)
```
$ bash scripts/forge-config-check.sh /path/to/spodi
errors:   0
warnings: 0
```

## Refs
- Spodi umbrella: maxgulyaev/spodi#316
- Spodi W1.1 PR (the broken-refs fix this atom enforces): maxgulyaev/spodi#317
- Spec: maxgulyaev/spodi PR #315

## Test plan
- [ ] `bash scripts/forge-config-check.test.sh` → 5/5 pass
- [ ] `bash scripts/forge-doctor.sh product /path/to/spodi` → shows new "OK forge-config-check" line
- [ ] Manually break a ref in spodi's `.forge/config.yaml`, re-run script → exits 1 and names the path