### PR TITLE
feat(plugin): extract gulyaev-forge as Claude Code plugin (v0.1.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin.json",
+  "name": "gulyaev-forge",
+  "displayName": "Gulyaev Forge — pipeline-driven product engineering",
+  "description": "Universal pipeline orchestrator for AI-agent-driven product engineering. 18 stage skills (strategy → discovery → PRD → design → architecture → implementation → code review → test coverage → QA → staging/canary deploy → product analytics → tech monitoring), 8 agent adapters (claude-code, codex, cursor, aider, cline, copilot, jules, windsurf), and 11 operator scripts. Stateless, agent-agnostic, designed to be lazy-loaded.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Max Gulyaev",
+    "url": "https://github.com/maxgulyaev"
+  },
+  "homepage": "https://github.com/maxgulyaev/gulyaev-forge",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/maxgulyaev/gulyaev-forge.git"
+  },
+  "license": "MIT",
+  "keywords": [
+    "pipeline",
+    "orchestration",
+    "agent-ready",
+    "code-review",
+    "stage-gates",
+    "forge"
+  ],
+  "skills_directory": "core/skills",
+  "scripts_directory": "scripts",
+  "templates_directory": "core/templates",
+  "adapters_directory": "adapters",
+  "commands_directory": "core/commands",
+  "_compat_notes": [
+    "Non-standard layout (core/skills/ not skills/) kept for backward compatibility with existing forge-stage-agent.sh + forge-doctor.sh which expect core/skills/<name>/SKILL.md. Future v0.2 may normalise to standard top-level skills/.",
+    "INDEX.yaml at core/skills/INDEX.yaml is the lazy-loaded skill catalogue per anatomy doc.",
+    "forge-config-check.sh enforces .forge/config.yaml integrity in consuming projects (e.g., maxgulyaev/spodi)."
+  ],
+  "_install_hint": {
+    "user_scope": "Add to ~/.claude/settings.json -> enabledPlugins after the marketplace lookup, OR clone the repo and reference via Personal scope.",
+    "marketplace_status": "Submitted to claude-community pending review (W3.4 of Agent-Ready 2026).",
+    "consumer_repos": ["maxgulyaev/spodi"]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] — 2026-05-24
+
+Initial plugin manifest extraction (W3.1 of Agent-Ready 2026 program — maxgulyaev/spodi#336).
+
+### Added
+- `.claude-plugin/plugin.json` declaring this repository as a Claude Code plugin.
+  - Non-standard `skills_directory: core/skills` preserved for backward compatibility with existing `forge-stage-agent.sh` + `forge-doctor.sh` paths.
+  - Version 0.1.0 (initial public manifest); the underlying skills/scripts/templates have been live in maxgulyaev/spodi since March 2026.
+- `LICENSE` (MIT).
+- This `CHANGELOG.md`.
+
+### Inherited (pre-manifest, pre-versioning)
+- 18 stage skills under `core/skills/<stage>/SKILL.md` (strategy → discovery → prd → design → architecture → test_plan → implementation → code_review → test_coverage → qa → staging_deploy → canary_deploy → product_analytics → tech_monitoring → investigate → scout → product-entry → self-entry).
+- 11 scripts under `scripts/` (forge-doctor, forge-status, forge-stage-agent, forge-issue-trail, forge-mcp, forge-init, forge-rules-check, forge-run-state, forge-release-scope, forge-release-target, forge-config-check, install-claude-commands).
+- 13 templates under `core/templates/`.
+- 8 agent adapters under `adapters/` (aider, claude-code, cline, codex, copilot, cursor, jules, windsurf).
+- 3 pipeline docs under `core/pipeline/` (orchestrator, issue-tracking, entry-surface).
+
+### Status of consuming projects
+- `maxgulyaev/spodi` consumes this repo via `~/Documents/Dev/gulyaev-forge/` reference and `.forge/config.yaml` overlay (W1.1 fixed 5 broken refs in that overlay; W1.7 added `forge-config-check.sh` to detect future breakage).
+
+### Out of scope for 0.1.0 (planned for 0.2.0+)
+- Layout normalisation (top-level `skills/` instead of `core/skills/`).
+- Public submission to the `claude-community` marketplace (W3.4 of Agent-Ready 2026).
+- Per-skill SKILL.md frontmatter audit (some inherited skills have inconsistent frontmatter).
+- Cross-link from spodi's `docs/agent-ready/governance.md` to this plugin manifest once 0.1.0 lands.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Max Gulyaev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
Minimum-viable plugin manifest for `gulyaev-forge`. Declares the repo as a Claude Code plugin without disrupting consuming projects.

**Added:**
- `.claude-plugin/plugin.json` — semver 0.1.0, 8 metadata fields, `skills_directory: core/skills` for back-compat
- `LICENSE` — MIT
- `CHANGELOG.md` — v0.1.0 entry

## Why non-standard layout
The Anthropic plugin spec wants top-level `skills/`. Forge currently has `core/skills/` because `forge-stage-agent.sh` + `forge-doctor.sh` + `INDEX.yaml` all reference that path. Normalising the layout would break consuming projects (maxgulyaev/spodi). Decision: keep `core/skills/` for v0.1.0; normalise in v0.2.0 with consumer migrations.

## Status
- Inherited (pre-manifest): 18 skills + 11 scripts + 13 templates + 8 adapters + 3 pipeline docs, all functional today
- Deferred to 0.2.0+: layout normalisation, marketplace submission, per-skill frontmatter audit, governance.md cross-link

## Refs
- maxgulyaev/spodi#336 (W3 umbrella)
- Anthropic plugin docs: https://code.claude.com/docs/en/plugins

## Test plan
- [ ] `python3 -c "import json; json.load(open('.claude-plugin/plugin.json'))"` parses clean
- [ ] All existing consumer scripts (`forge-doctor self`, `forge-doctor product /path/to/spodi`) still pass on the same content
- [ ] Repo still readable as a regular git repo (no breaking restructure)
