### PR TITLE
fix(plugin): bump to v0.1.1 — spec-compliant manifest + correct submission URLs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,40 +1,12 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "gulyaev-forge",
-  "displayName": "Gulyaev Forge — pipeline-driven product engineering",
-  "description": "Universal pipeline orchestrator for AI-agent-driven product engineering. 18 stage skills (strategy → discovery → PRD → design → architecture → implementation → code review → test coverage → QA → staging/canary deploy → product analytics → tech monitoring), 8 agent adapters (claude-code, codex, cursor, aider, cline, copilot, jules, windsurf), and 11 operator scripts. Stateless, agent-agnostic, designed to be lazy-loaded.",
-  "version": "0.1.0",
+  "description": "Pipeline orchestrator for AI-agent-driven product engineering — 18 stage skills (strategy → discovery → PRD → design → architecture → implementation → code review → test coverage → QA → staging/canary deploy → product analytics → tech monitoring), 8 agent adapters, 11 operator scripts. Used in production by maxgulyaev/spodi.",
+  "version": "0.1.1",
   "author": {
     "name": "Max Gulyaev",
     "url": "https://github.com/maxgulyaev"
   },
   "homepage": "https://github.com/maxgulyaev/gulyaev-forge",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/maxgulyaev/gulyaev-forge.git"
-  },
-  "license": "MIT",
-  "keywords": [
-    "pipeline",
-    "orchestration",
-    "agent-ready",
-    "code-review",
-    "stage-gates",
-    "forge"
-  ],
-  "skills_directory": "core/skills",
-  "scripts_directory": "scripts",
-  "templates_directory": "core/templates",
-  "adapters_directory": "adapters",
-  "commands_directory": "core/commands",
-  "_compat_notes": [
-    "Non-standard layout (core/skills/ not skills/) kept for backward compatibility with existing forge-stage-agent.sh + forge-doctor.sh which expect core/skills/<name>/SKILL.md. Future v0.2 may normalise to standard top-level skills/.",
-    "INDEX.yaml at core/skills/INDEX.yaml is the lazy-loaded skill catalogue per anatomy doc.",
-    "forge-config-check.sh enforces .forge/config.yaml integrity in consuming projects (e.g., maxgulyaev/spodi)."
-  ],
-  "_install_hint": {
-    "user_scope": "Add to ~/.claude/settings.json -> enabledPlugins after the marketplace lookup, OR clone the repo and reference via Personal scope.",
-    "marketplace_status": "Submitted to claude-community pending review (W3.4 of Agent-Ready 2026).",
-    "consumer_repos": ["maxgulyaev/spodi"]
-  }
+  "repository": "https://github.com/maxgulyaev/gulyaev-forge",
+  "license": "MIT"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] — 2026-05-24
+
+Post-W3.1 fact-check after reading official Anthropic plugin docs (https://code.claude.com/docs/en/plugins). v0.1.0 manifest had several non-compliant fields and wrong submission URL in SUBMISSION.md.
+
+### Fixed
+- `.claude-plugin/plugin.json` — stripped invented fields (`skills_directory`, `scripts_directory`, `templates_directory`, `adapters_directory`, `commands_directory`, `_compat_notes`, `_install_hint`, `keywords`). Manifest now matches the official schema: `name`, `description`, `version`, `author`, `homepage`, `repository`, `license` only.
+- `skills/` added as a symlink to `core/skills/` so Claude Code can find the skill catalogue at the spec-required location while existing forge scripts (`forge-doctor.sh`, `forge-stage-agent.sh`, `INDEX.yaml`) continue to reference `core/skills/`.
+- `SUBMISSION.md` — corrected submission URLs from the wrong `clau.de/plugin-directory-submission` to the official `https://claude.ai/settings/plugins/submit` and `https://platform.claude.com/plugins/submit`. Added `claude plugin validate` note (command not in CLI 2.1.150 yet; submission form runs it server-side).
+- `SUBMISSION.md` — noted plugin skills will be namespaced as `/gulyaev-forge:<skill>` (per official docs, plugin skills are ALWAYS namespaced).
+
+### Deferred to 0.2.0
+- Skills layout normalisation: remove the symlink, move `core/skills/` to top-level `skills/` for real, update internal script refs.
+- `agents/` subdir with actual Claude subagent definitions (current `adapters/` is per-CLI translators, not subagents).
+- Per-skill SKILL.md frontmatter audit (need `description:` on every SKILL.md for Claude auto-invocation).
+- `bin/` for scripts that should be on `$PATH` while plugin is enabled.
+
 ## [0.1.0] — 2026-05-24
 
 Initial plugin manifest extraction (W3.1 of Agent-Ready 2026 program — maxgulyaev/spodi#336).

--- a/SUBMISSION.md
+++ b/SUBMISSION.md
@@ -1,78 +1,97 @@
 # Claude Code marketplace submission checklist
 
-W3.4 of Agent-Ready 2026 program (maxgulyaev/spodi#336). Step-by-step preparation for submitting gulyaev-forge to the claude-community marketplace.
+W3.4 of Agent-Ready 2026 program (maxgulyaev/spodi#336), corrected per official Anthropic plugin docs (W3.1b).
 
-**Status as of 2026-05-24:** v0.1.0 manifest live (`.claude-plugin/plugin.json`), CHANGELOG present, MIT LICENSE present. Ready for submission once the user completes the steps below.
+**Status as of 2026-05-24:** v0.1.1 manifest live (`.claude-plugin/plugin.json`), `skills/` symlinked to `core/skills/` for spec compliance, LICENSE + CHANGELOG present.
 
-## How the submission process works (2026-05)
+## How the submission process works (2026-05, per official docs)
 
-- The official channel is the submission form at **https://clau.de/plugin-directory-submission**.
-- Direct pull requests against `anthropics/claude-plugins-community` are auto-closed; the form is the only accepted route.
-- Anthropic runs automated validation + safety screening before adding plugins to the directory.
-- An "Anthropic Verified" badge requires additional review by Anthropic staff (quality + safety perspective).
+- The official channels are the in-app submission forms:
+  - **Claude.ai**: https://claude.ai/settings/plugins/submit
+  - **Console**: https://platform.claude.com/plugins/submit
+- Anthropic runs `claude plugin validate` on submission AND automated safety screening.
+- Approved plugins are pinned to a specific commit SHA in `anthropics/claude-plugins-community`.
+- CI bumps the pin automatically as you push new commits.
+- Catalog syncs nightly; expect a delay between approval and `marketplace.json` appearance.
 
-## Pre-flight checklist (verify before submitting)
+The official `claude-plugins-official` directory is **curated by Anthropic**. The submission form does NOT add plugins there. We're aiming for `claude-community` only.
+
+## Pre-flight checklist
 
 - [x] `.claude-plugin/plugin.json` exists at repo root and parses as valid JSON
-- [x] `plugin.json` declares `name`, `description`, `version`, `author`, `license`
-- [x] Version follows semver (currently `0.1.0`)
+- [x] Manifest fields are spec-compliant only (`name`, `description`, `version`, `author`, `homepage`, `repository`, `license`) — no invented `_compat_notes` / `skills_directory` etc.
+- [x] Version follows semver (currently `0.1.1`)
 - [x] `LICENSE` file at repo root (MIT)
 - [x] `CHANGELOG.md` with at least one entry
 - [x] `README.md` explains what the plugin does, how to install, and example usage
-- [ ] No secrets in tracked files (`git grep -E "ghp_|ghs_|gho_|github_pat_|sk-ant-" -- '*'` returns nothing)
-- [ ] No machine-specific absolute paths in tracked files (`/Users/maxgulyaev/` etc.)
-- [ ] All shell scripts are POSIX-friendly OR clearly require bash (no zsh-only constructs)
-- [ ] All skill `SKILL.md` files have a frontmatter `name:` and `description:` (the `description:` is what Claude uses to match the skill to a task — clear triggers boost activation rate per Habr AI Kit case)
+- [x] `skills/` exists at repo root (symlink to `core/skills/` for back-compat with existing forge scripts)
+- [ ] `claude plugin validate` runs clean — **BLOCKED:** command not in Claude Code 2.1.150 CLI yet. The submission form will run it server-side. Local pre-check deferred until CLI exposes the command.
+- [ ] `git grep -E "ghp_|ghs_|gho_|github_pat_|sk-ant-"` returns no matches (no secrets)
+- [ ] No machine-specific absolute paths in tracked files
+- [ ] All shell scripts run with `bash` (zsh-only constructs flagged in PR review)
+- [ ] Each `SKILL.md` has frontmatter `description:` — important: it's what Claude uses to auto-invoke the skill
 
 ## Submission form fields (prepare these strings)
 
-When the user opens https://clau.de/plugin-directory-submission, they will need:
+When opening https://claude.ai/settings/plugins/submit or https://platform.claude.com/plugins/submit:
 
 **Plugin name:** `gulyaev-forge`
 
-**Tagline (1 line):** `Universal pipeline orchestrator for AI-agent-driven product engineering — 18 stage skills + 8 agent adapters.`
+**Plugin namespace (auto, FYI):** After install, skills will be `/gulyaev-forge:<skill-name>` (e.g., `/gulyaev-forge:strategy`, `/gulyaev-forge:code-review`). Per official docs, plugin skills are ALWAYS namespaced to prevent conflicts.
 
-**Description (longer):**
+**Tagline / short description:** `Universal pipeline orchestrator for AI-agent-driven product engineering — 18 stage skills + 8 agent adapters.`
+
+**Long description:**
 ```
-Gulyaev Forge is a Claude Code plugin that turns a fitness-tracking product team into a pipeline-driven shop. It ships 18 stage skills (strategy → discovery → PRD → design → architecture → test plan → implementation → code review → test coverage → QA → staging/canary deploy → product analytics → tech monitoring), 8 agent adapters (claude-code, codex, cursor, aider, cline, copilot, jules, windsurf), 11 operator scripts (forge-doctor, forge-status, forge-stage-agent, forge-config-check, ...), and 13 stage templates.
+Gulyaev Forge is a Claude Code plugin that turns a product team into a pipeline-driven shop. It ships 18 stage skills (strategy → discovery → PRD → design → architecture → test plan → implementation → code review → test coverage → QA → staging/canary deploy → product analytics → tech monitoring → investigate / scout / product-entry / self-entry), 8 agent adapters (claude-code, codex, cursor, aider, cline, copilot, jules, windsurf), 11 operator scripts (forge-doctor, forge-status, forge-stage-agent, forge-config-check, forge-issue-trail, forge-mcp, forge-init, forge-rules-check, forge-run-state, forge-release-scope, forge-release-target), and 13 stage templates.
 
-The Enterprise tier of a 3-tier hierarchy (Enterprise / Project / Personal). Designed to be lazy-loaded — agents pick up only the stage skill they need via INDEX.yaml dispatch, not all 18 at once.
+Forge is the Enterprise tier of a 3-tier hierarchy (Enterprise / Project / Personal). Designed to be lazy-loaded — agents pick up only the stage skill they need via INDEX.yaml dispatch, not all 18 at once.
 
-Used in production by maxgulyaev/spodi (a Russian-language fitness app) where it drove the 2026 Q2 Agent-Ready program (safety scaffolding + cost economy + multi-agent CI review wiring).
+Used in production by maxgulyaev/spodi (a Russian-language fitness app) where it drove the 2026 Q2 Agent-Ready program: safety scaffolding + cost economy + multi-agent CI review wiring.
 ```
 
 **Repository URL:** `https://github.com/maxgulyaev/gulyaev-forge`
 
 **License:** `MIT`
 
-**Categories / tags:** `pipeline`, `orchestration`, `code-review`, `stage-gates`, `agent-ready`, `multi-agent`
+**Tags / categories:** `pipeline`, `orchestration`, `code-review`, `stage-gates`, `agent-ready`, `multi-agent`, `forge`
 
-**Maintainer contact:** Max Gulyaev (GitHub: @maxgulyaev)
+**Maintainer:** Max Gulyaev (@maxgulyaev)
 
-**Example install command (for the form):**
+**After install, users run:**
 ```
 /plugin marketplace add anthropics/claude-plugins-community
 /plugin install gulyaev-forge@claude-community
 ```
 
-**Why anyone else would want this plugin:** any team running Claude Code on a real product that wants stage-gates + multi-adapter support + lazy-loaded skills without inventing the pipeline themselves.
-
 ## After submission
 
-1. Save the submission ID (the form returns one).
-2. Watch the GitHub repo for an Anthropic automated check (usually within 48h per the docs).
-3. If validation fails, fix in a follow-up PR + re-submit the form with the new commit SHA.
-4. Once accepted, the plugin will appear in `claude-community` and be installable via `/plugin install gulyaev-forge`.
+1. Save the submission ID returned by the form.
+2. The review pipeline runs automated validation. Watch for results (per official docs there's "a delay between approval and your plugin appearing in marketplace.json" while the nightly catalog sync happens).
+3. If validation fails, fix in a follow-up commit + re-submit form with the new commit SHA.
+4. Once accepted, the plugin appears in `claude-community`. Users install via the commands above.
 
-## Known gaps vs marketplace recommendation (for v0.2.0)
+## Known v0.2.0 work (post-submission polish)
 
-- Layout normalisation: standard plugins put skills at top-level `skills/`. Forge currently uses `core/skills/`. Marketplace will still accept it (we declare `skills_directory: core/skills` in the manifest), but normalising would simplify discovery.
-- No `agents/` subdir today — forge has `adapters/` instead. Spec wants agents.
-- Per-skill SKILL.md frontmatter audit pending. Some inherited skills may have missing `description:` fields.
+These are NOT blockers for v0.1.1 submission but should land before pursuing the "Anthropic Verified" badge:
 
-These do NOT block v0.1.0 submission but should ship in v0.2.0 before the "Anthropic Verified" badge becomes meaningful.
+- **Skills layout normalisation** — currently `skills/` is a symlink to `core/skills/`. Move to a real directory and update `forge-doctor.sh` / `forge-stage-agent.sh` to use the new path; remove the symlink. Spodi consumer side (`.forge/config.yaml`) doesn't reference forge skills directly so no consumer migration needed.
+- **`agents/` subdir** — official spec wants agent definitions there. Forge has `adapters/` instead (per-CLI-tool translators, not Claude subagents). Either rename or add a separate `agents/` with actual subagent definitions.
+- **Per-skill SKILL.md frontmatter audit** — some inherited skills may have missing `description:` fields. Without `description:`, Claude can't auto-invoke the skill (per official docs: "Include a `description` so Claude knows when to use the skill").
+- **`bin/` directory** — if any forge script should be on the user's `$PATH` while the plugin is enabled, move to `bin/` per spec.
+- **`hooks/hooks.json`** — if forge ships hooks, they go here, NOT in `settings.json`.
+- **`monitors/monitors.json`** — if forge wants to ship background monitors (e.g., a status-poll), add here.
+- **`claude plugin validate`** locally once the CLI exposes the command.
 
 ## After this PR
 
-- The user (Max) opens https://clau.de/plugin-directory-submission and fills the form using the strings above.
-- W3 of Agent-Ready 2026 is effectively closed — the remaining work is the platform-side review + any v0.2.0 polish.
+- User (Max) opens https://claude.ai/settings/plugins/submit or https://platform.claude.com/plugins/submit and fills the form using the strings above.
+- W3 of Agent-Ready 2026 is effectively closed — remaining work is platform-side review + any v0.2.0 polish.
+
+## Refs
+
+- Official Anthropic plugin docs: https://code.claude.com/docs/en/plugins
+- Plugin reference: https://code.claude.com/docs/en/plugins-reference
+- Discover plugins: https://code.claude.com/docs/en/discover-plugins
+- Plugin marketplaces: https://code.claude.com/docs/en/plugin-marketplaces
+- Community catalog: https://github.com/anthropics/claude-plugins-community

--- a/skills
+++ b/skills
@@ -1,0 +1,1 @@
+core/skills


### PR DESCRIPTION
## Summary
Post-publication fact-check against official Anthropic plugin docs caught real spec violations in v0.1.0:

1. `plugin.json` had 8 invented fields (`skills_directory`, `_compat_notes`, etc.) — stripped.
2. Skills weren't at the spec-required `skills/` location — added symlink to `core/skills/`.
3. `SUBMISSION.md` had wrong submission URL (`clau.de/plugin-directory-submission`) — corrected to `https://claude.ai/settings/plugins/submit` and `https://platform.claude.com/plugins/submit`.
4. Forgot to mention skills get namespaced (`/gulyaev-forge:strategy` not `/strategy`).
5. Forgot `claude plugin validate` pre-flight (it's documented but not in CLI 2.1.150 yet — server-side run via the form).

Bumped to v0.1.1 with CHANGELOG entry.

## What stays back-compat
The `skills/ → core/skills/` symlink means existing forge scripts that reference `core/skills/<stage>/SKILL.md` continue to work. Consumer side (spodi) uses path references to `~/Documents/Dev/gulyaev-forge/` which still resolve. Nothing breaks downstream.

## What's still deferred to 0.2.0
- Real layout normalisation (remove symlink)
- `agents/` subdir with Claude subagent definitions (current `adapters/` is per-CLI translators)
- Per-skill SKILL.md frontmatter audit
- `bin/` directory

## Refs
- Official docs: https://code.claude.com/docs/en/plugins
- Plugin reference: https://code.claude.com/docs/en/plugins-reference
- maxgulyaev/spodi#336 (W3 umbrella)
