### PR TITLE
fix(plugin): v0.1.2 — frontmatter on all skills + validate clean (1 warning vs 15)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gulyaev-forge",
-  "description": "Pipeline orchestrator for AI-agent-driven product engineering — 18 stage skills (strategy → discovery → PRD → design → architecture → implementation → code review → test coverage → QA → staging/canary deploy → product analytics → tech monitoring), 8 agent adapters, 11 operator scripts. Used in production by maxgulyaev/spodi.",
-  "version": "0.1.1",
+  "description": "Pipeline orchestrator for AI-agent-driven product engineering \u2014 18 stage skills (strategy \u2192 discovery \u2192 PRD \u2192 design \u2192 architecture \u2192 implementation \u2192 code review \u2192 test coverage \u2192 QA \u2192 staging/canary deploy \u2192 product analytics \u2192 tech monitoring), 8 agent adapters, 11 operator scripts. Used in production by maxgulyaev/spodi.",
+  "version": "0.1.2",
   "author": {
     "name": "Max Gulyaev",
     "url": "https://github.com/maxgulyaev"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] — 2026-05-24
+
+Post-W3.1b codex review (PASS_WITH_CHANGES) — caught that `claude plugin validate` IS in Claude Code 2.1.150 (earlier note saying it was unavailable was wrong) and that 15 validation warnings were live.
+
+### Fixed
+- All 14 forge stage skills (`core/skills/architecture/SKILL.md`, `code-review`, `design`, `discovery`, `implementation`, `prd`, `product-analytics`, `qa`, `staging-deploy`, `canary-deploy`, `strategy`, `tech-monitoring`, `test-coverage`, `test-plan`) now have YAML frontmatter with `name:` + `description:`. Description text is the consumer-facing trigger (e.g., strategy: "Use when defining or refreshing product strategy …"). Per official docs, `description:` is what Claude uses to auto-invoke the skill.
+- SUBMISSION.md updated: removed the false "validate not available in 2.1.150" claim. Added a "Why the remaining CLAUDE.md warning is intentional" section explaining the contributor-router rationale.
+
+### Validation status
+- `claude plugin validate .` → 1 warning, 0 errors (was 15 warnings).
+- `claude plugin validate --strict .` → still fails on the 1 remaining `CLAUDE.md` warning. v0.2.0 will rename CLAUDE.md → CONTRIBUTING.md to clear strict mode.
+
+### Already in v0.1.1 (carry-over reminder)
+- spec-compliant manifest (only `name`, `description`, `version`, `author`, `homepage`, `repository`, `license`)
+- `skills` symlink → `core/skills` for spec-required location with back-compat to existing forge scripts
+
 ## [0.1.1] — 2026-05-24
 
 Post-W3.1 fact-check after reading official Anthropic plugin docs (https://code.claude.com/docs/en/plugins). v0.1.0 manifest had several non-compliant fields and wrong submission URL in SUBMISSION.md.

--- a/SUBMISSION.md
+++ b/SUBMISSION.md
@@ -25,7 +25,7 @@ The official `claude-plugins-official` directory is **curated by Anthropic**. Th
 - [x] `CHANGELOG.md` with at least one entry
 - [x] `README.md` explains what the plugin does, how to install, and example usage
 - [x] `skills/` exists at repo root (symlink to `core/skills/` for back-compat with existing forge scripts)
-- [ ] `claude plugin validate` runs clean — **BLOCKED:** command not in Claude Code 2.1.150 CLI yet. The submission form will run it server-side. Local pre-check deferred until CLI exposes the command.
+- [x] `claude plugin validate .` passes (Claude Code 2.1.150 DOES expose the command — earlier note was wrong). Currently 1 advisory warning about plugin-root `CLAUDE.md` not being loaded as plugin context (intentional — that CLAUDE.md is for forge contributors, not plugin consumers; documented below). `claude plugin validate --strict .` fails on warnings; for now we ship with warnings.
 - [ ] `git grep -E "ghp_|ghs_|gho_|github_pat_|sk-ant-"` returns no matches (no secrets)
 - [ ] No machine-specific absolute paths in tracked files
 - [ ] All shell scripts run with `bash` (zsh-only constructs flagged in PR review)
@@ -63,6 +63,14 @@ Used in production by maxgulyaev/spodi (a Russian-language fitness app) where it
 /plugin marketplace add anthropics/claude-plugins-community
 /plugin install gulyaev-forge@claude-community
 ```
+
+### Why the remaining CLAUDE.md warning is intentional
+
+`claude plugin validate` emits 1 warning:
+
+> CLAUDE.md at the plugin root is not loaded as project context. To ship context with your plugin, use a skill (skills/<name>/SKILL.md) instead.
+
+Forge's root `CLAUDE.md` is the **contributor router** — it guides agents that are working ON forge itself (writing new skills, debugging the pipeline). Plugin **consumers** never see this file; they install the plugin and invoke `/gulyaev-forge:<skill-name>` directly. The warning is informational, not an error. We accept it for v0.1.x; v0.2.0 will rename to `CONTRIBUTING.md` once internal refs are updated.
 
 ## After submission
 

--- a/core/skills/architecture/SKILL.md
+++ b/core/skills/architecture/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: architecture
+description: Use when designing the technical architecture for an approved PRD/design — system topology, data model, API contracts, infra changes. Stage 4.
+---
+
 # Pipeline Stage 4: Architecture
 
 ## Role

--- a/core/skills/canary-deploy/SKILL.md
+++ b/core/skills/canary-deploy/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: canary-deploy
+description: Use when deploying an approved candidate to production canary (a subset of users) before full rollout. Stage 10.
+---
+
 # Pipeline Stage 10: Canary Deploy
 
 ## Role

--- a/core/skills/code-review/SKILL.md
+++ b/core/skills/code-review/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: code-review
+description: Use during Stage 6.5 external code review — verify implementation follows the approved contract, uses TDD discipline, no regressions. Runs after implementation, before test_coverage.
+---
+
 # Pipeline Stage 6.5: Code Review
 
 ## Role

--- a/core/skills/design/SKILL.md
+++ b/core/skills/design/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: design
+description: Use when designing UX/UI for an approved PRD. Wireframes, flows, copy, design tokens. Stage 3.
+---
+
 # Pipeline Stage 3: Design
 
 ## Role

--- a/core/skills/discovery/SKILL.md
+++ b/core/skills/discovery/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: discovery
+description: Use when investigating an unsolved problem before committing to a solution — user research, competitive scan, technology evaluation, prior-art search. Produces a Discovery Report.
+---
+
 # Pipeline Stage 1: Discovery
 
 ## Role

--- a/core/skills/implementation/SKILL.md
+++ b/core/skills/implementation/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: implementation
+description: Use during the code-writing stage after architecture + test plan are approved. Writes the production code + tests per the Behavior Contract. Stage 6.
+---
+
 # Pipeline Stage 6: Implementation
 
 ## Role

--- a/core/skills/prd/SKILL.md
+++ b/core/skills/prd/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: prd
+description: Use when writing a Product Requirements Document for an approved discovery output. Defines what to build, acceptance criteria, and out-of-scope items. Stage 2.
+---
+
 # Pipeline Stage 2: Behavior Contract
 
 ## Role

--- a/core/skills/product-analytics/SKILL.md
+++ b/core/skills/product-analytics/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: product-analytics
+description: Use when analysing product metrics post-launch — funnel health, cohort retention, A/B results, decision memos. Stage 11.
+---
+
 # Pipeline Stage 11: Product Analytics
 
 ## Role

--- a/core/skills/qa/SKILL.md
+++ b/core/skills/qa/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: qa
+description: Use during Stage 8 QA — runs manual + automated checks on a testable environment (local, staging, prod canary). Produces a QA Gate verdict.
+---
+
 # Pipeline Stage 8: Automated QA
 
 ## Role

--- a/core/skills/staging-deploy/SKILL.md
+++ b/core/skills/staging-deploy/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: staging-deploy
+description: Use when deploying an approved candidate to staging. Stage 9.
+---
+
 # Pipeline Stage 9: Staging Deploy
 
 ## Role

--- a/core/skills/strategy/SKILL.md
+++ b/core/skills/strategy/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: strategy
+description: Use when defining or refreshing product strategy — vision, positioning, target metrics, roadmap. Greenfield products, quarterly reviews, post-analytics decisions (continue/amplify/pivot/kill).
+---
+
 # Pipeline Stage 0: Strategy
 
 ## Role

--- a/core/skills/tech-monitoring/SKILL.md
+++ b/core/skills/tech-monitoring/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: tech-monitoring
+description: Use when reviewing technical-health metrics post-launch — error rates, latency, infra cost, incident trends. Stage 12.
+---
+
 # Pipeline Stage 12: Tech Monitoring
 
 ## Role

--- a/core/skills/test-coverage/SKILL.md
+++ b/core/skills/test-coverage/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: test-coverage
+description: Use when measuring and improving test coverage post-implementation — find uncovered branches, add tests, mark BUSINESS_RULES rules [x] only with proof at matching strength level. Stage 7.
+---
+
 # Pipeline Stage 7: Test Coverage
 
 ## Role

--- a/core/skills/test-plan/SKILL.md
+++ b/core/skills/test-plan/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: test-plan
+description: Use when authoring a test plan for an approved architecture — coverage matrix, fixtures, environments, exit criteria. Stage 5.
+---
+
 # Pipeline Stage 5: Proof Hardening
 
 ## Role


### PR DESCRIPTION
## Summary
Bump to v0.1.2.

Fixes 14 SKILL.md files missing YAML frontmatter (per `claude plugin validate`). Also corrects the false "validate not in 2.1.150" claim from v0.1.1 — the command IS there and ran clean (passes with 1 advisory warning).

## Validation
| | v0.1.1 | v0.1.2 |
|---|---|---|
| `claude plugin validate .` | 15 warnings | **1 warning** |
| `claude plugin validate --strict .` | fails | fails (1 CLAUDE.md warning remains; v0.2.0 rename will clear it) |

## Per-skill description text
Each of 14 skills got a one-sentence consumer-facing trigger. Example:
> strategy: "Use when defining or refreshing product strategy — vision, positioning, target metrics, roadmap. Greenfield products, quarterly reviews, post-analytics decisions (continue/amplify/pivot/kill)."

## Why the remaining warning is intentional
Forge's root CLAUDE.md is the **contributor router** — it guides agents working ON forge itself. Plugin consumers never see this file; they install + invoke `/gulyaev-forge:<skill>` directly. Rename to CONTRIBUTING.md is v0.2.0 work.

## Refs
- Codex W3.1b review: gulyaev-forge#5 thread
- maxgulyaev/spodi#336 (W3 umbrella)
